### PR TITLE
Comment out code in infer/mcmc.hpp that uses a fixed port address

### DIFF
--- a/src/infer/mcmc.hpp
+++ b/src/infer/mcmc.hpp
@@ -105,8 +105,8 @@ namespace stateline
         using namespace std::chrono;
 
         // Used for publishing statistics to visualisation server.
-        zmq::socket_t publisher(context_, ZMQ_PUB);
-        publisher.bind("tcp://*:5556");
+        //zmq::socket_t publisher(context_, ZMQ_PUB);
+        //publisher.bind("tcp://*:5556");
 
         // Record the starting time of the MCMC
         steady_clock::time_point startTime = steady_clock::now();
@@ -256,7 +256,7 @@ namespace stateline
             }
 
             // Quick and dirty way to get the data to the visualisation server
-            comms::sendString(publisher, s.str());
+            //comms::sendString(publisher, s.str());
 
             if (duration_cast<milliseconds>(steady_clock::now() - lastPrintTime).count() > 500)
             {

--- a/src/prior/fieldobs.hpp
+++ b/src/prior/fieldobs.hpp
@@ -1,0 +1,24 @@
+// Copyright (c) 2014, 2018 NICTA + USyd.
+// This file is licensed under the General Public License version 3 or later.
+// See the COPYRIGHT file.
+
+/**
+ * Prior object
+ *
+ * @file fieldobs.hpp
+ * @author Richard Scalzo
+ * @date March 2018
+ */
+
+#pragma once
+
+namespace obsidian
+{
+  namespace prior
+  {
+    class FieldObsParamsPrior
+    {
+
+    };
+  }
+}

--- a/src/serial/testfieldobs.cpp
+++ b/src/serial/testfieldobs.cpp
@@ -1,0 +1,33 @@
+// Copyright (c) 2014, NICTA.
+// This file is licensed under the General Public License version 3 or later.
+// See the COPYRIGHT file.
+
+/**
+ * Contains the basic GDF datatypes for communication between forward models.
+ *
+ * @file testcontactpoint.hpp
+ * @author Nahid Akbar
+ * @date 2014
+ */
+
+#include "serial/fieldobs.hpp"
+#include "test/serial.hpp"
+#include "test/fieldobs.hpp"
+
+namespace obsidian
+{
+TEST_F(Serialise, testSpec)
+{
+  generateVariations<FieldObsSpec>(test<FieldObsSpec>);
+}
+
+TEST_F(Serialise, testParams)
+{
+  generateVariations<FieldObsParams>(test<FieldObsParams>);
+}
+
+TEST_F(Serialise, testResults)
+{
+  generateVariations<FieldObsResults>(test<FieldObsResults>);
+}
+}


### PR DESCRIPTION
Comment out code in src/infer/mcmc.hpp that uses a fixed port address for the visualization server.
This allows multiple experiments (i.e. starting multiple obsidian servers on a cluster) to be conducted at once without the experiments trying to access the same port if the obsidian servers happen to be started on the same host on the cluster.